### PR TITLE
VIS-1946 g3 replace validate func with assert_type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class redis_sentinel (
   $group          = 'redis',
 ) {
 
-  validate_bool($service_enable)
+  assert_type(Boolean, $service_enable)
 
   class { 'redis_sentinel::install': } ->
   class { 'redis_sentinel::config': } ~>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced deprecated `validate_bool` function with `assert_type`.

- Improved type validation for `$service_enable` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init.pp</strong><dd><code>Updated type validation in `manifests/init.pp`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/init.pp

<li>Replaced <code>validate_bool</code> with <code>assert_type</code> for <code>$service_enable</code>.<br> <li> Ensured compatibility with modern Puppet type validation.


</details>


  </td>
  <td><a href="https://github.com/opentable/puppet-redis_sentinel/pull/7/files#diff-c6c3a824d185ff01e063011517a1b13a604dc3d7b63d1c67a30451c10df02bcb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>