### PR TITLE
VIS-1946 g3 Remove missing field from the code

### DIFF
--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -24,7 +24,6 @@ define redis_sentinel::monitor (
 
   include redis_sentinel
   concat::fragment { "redis_sentinel_${name}":
-    ensure  => $ensure,
     target  => $redis_sentinel::config_file,
     content => template('redis_sentinel/monitor.erb'),
   }


### PR DESCRIPTION
### **User description**
*There is a breaking change for Puppet5 in this*
In the updated version of the module `concat::fragment` there is no field available as `ensure`.
We are removing this field from being referenced in redis_sentinel code. We have to make sure we don't use this version of redis_sentinel on puppet5 but on puppet8.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the unsupported `ensure` field from `concat::fragment`.

- Ensured compatibility with updated `concat::fragment` module.

- Addressed breaking changes for Puppet5 in `redis_sentinel` code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>monitor.pp</strong><dd><code>Remove unsupported `ensure` field from `concat::fragment`</code></dd></summary>
<hr>

manifests/monitor.pp

<li>Removed the <code>ensure</code> field from <code>concat::fragment</code>.<br> <li> Updated to align with the updated <code>concat::fragment</code> module.


</details>


  </td>
  <td><a href="https://github.com/opentable/puppet-redis_sentinel/pull/8/files#diff-ec7ee3a7481e51886b45d3eb13e0d65684451c2bd1102863c53576f01aa60ed9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>